### PR TITLE
读取`config.ini`时使用utf-8编码

### DIFF
--- a/tool.py
+++ b/tool.py
@@ -126,7 +126,7 @@ def goodTool() -> None:
 def addressTool() -> None:
     conf = configparser.RawConfigParser()
     try:
-        conf.read_file(open("config.ini"))
+        conf.read_file(open("config.ini", encoding="utf-8"))
         cookie = conf.get(
             "Config",
             "Cookie").strip("'''").strip("'").strip("\"\"\"").strip("\"")
@@ -221,7 +221,7 @@ def addressTool() -> None:
 
         try:
             conf.set("Config", "Address_ID", choice)
-            with open("config.ini", "w") as config_file:
+            with open("config.ini", "w", encoding="utf-8") as config_file:
                 conf.write(config_file)
             print("> 配置文件写入成功(回车以返回功能选择界面)")
             input()
@@ -338,7 +338,7 @@ def cookieTool() -> None:
                 if "stoken" in cookies and conf.get("Config",
                                                     "stoken") != None:
                     conf.set("Config", "stoken", cookies["stoken"])
-                with open("config.ini", "w") as config_file:
+                with open("config.ini", "w", encoding="utf-8") as config_file:
                     conf.write(config_file)
 
                 print("> 配置文件写入成功(回车以返回功能选择界面)")


### PR DESCRIPTION
将打开`config.ini`时的使用的编码统一为utf-8，避免python因使用平台默认编码(如gbk)而无法解码`config.ini`的情况。
错误提示：
```
UnicodeDecodeError: 'gbk' codec can't decode byte xxx in position xxx: illegal multibyte sequence
```